### PR TITLE
Bgr subtraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Plot-EPR-spectra
-Automates the plotting of EPR spectra, including normalisation and subtracting background spectrum
+Automates the plotting of EPR spectra, including normalisation and subtracting background spectrum. This is mostly to increase the efficiency of my personal research.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Plot-EPR-spectra
-Automates the plotting of EPR spectra, including normalisation and subtracting background spectrum. This is mostly to increase the efficiency of my personal research.
+Automates the plotting of EPR spectra, including normalisation and subtracting background spectrum. In this branch I want to add the optionality to subtract a background spectrum for very low S/N situations where the cavity background influences the baseline and thus makes the integration boubtful.


### PR DESCRIPTION
Optionality to subtract a BGR spectrum in very low S/N cases to deal with baselining issues related to integration of the spectra